### PR TITLE
Add Scala 3 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6, 2.12.14]
+        scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -122,6 +122,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,5 +1,9 @@
 ThisBuild / scalaVersion := Dependencies.Versions.scala213
-ThisBuild / crossScalaVersions := Seq(Dependencies.Versions.scala213, Dependencies.Versions.scala212)
+ThisBuild / crossScalaVersions := Seq(
+  Dependencies.Versions.scala213,
+  Dependencies.Versions.scala212,
+  Dependencies.Versions.scala3
+)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,10 +4,11 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
+    val scala3 = "3.0.1"
 
-    val trace4cats = "0.12.0-RC2"
-    val trace4catsExporterHttp = "0.12.0-RC2"
-    val trace4catsJaegerIntegrationTest = "0.12.0-RC2"
+    val trace4cats = "0.12.0-RC2+17-d73c7ff3"
+    val trace4catsExporterHttp = "0.12.0-RC2+4-5c079741"
+    val trace4catsJaegerIntegrationTest = "0.12.0-RC2+7-79169288"
 
     val circe = "0.14.1"
     val http4s = "0.23.0-RC1"
@@ -23,8 +24,8 @@ object Dependencies {
   lazy val trace4catsJaegerIntegrationTest =
     "io.janstenpickle" %% "trace4cats-jaeger-integration-test" % Versions.trace4catsJaegerIntegrationTest
 
-  lazy val circeGeneric = "io.circe"        %% "circe-generic-extras" % Versions.circe
-  lazy val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client"  % Versions.http4s
+  lazy val circeGeneric = "io.circe"        %% "circe-generic"       % Versions.circe
+  lazy val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
 
   lazy val kindProjector = ("org.typelevel" % "kind-projector"     % Versions.kindProjector).cross(CrossVersion.full)
   lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor


### PR DESCRIPTION
circe-generic works as a drop-in for circe-generic-extras here as no extra features were used.

Depends on https://github.com/trace4cats/trace4cats/pull/587