### PR TITLE
Remove Blaze client dependency, take a typed Uri in constructors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,6 @@ lazy val `zipkin-http-exporter` =
       name := "trace4cats-zipkin-http-exporter",
       libraryDependencies ++= Seq(
         Dependencies.circeGeneric,
-        Dependencies.http4sBlazeClient,
         Dependencies.trace4catsModel,
         Dependencies.trace4catsKernel,
         Dependencies.trace4catsExporterCommon,

--- a/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleter.scala
+++ b/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleter.scala
@@ -32,8 +32,6 @@ object ZipkinHttpSpanCompleter {
     config: CompleterConfig
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
-      Resource
-        .pure(ZipkinHttpSpanExporter[F, Chunk](client, uri))
-        .flatMap(QueuedSpanCompleter[F](process, _, config))
+      QueuedSpanCompleter[F](process, ZipkinHttpSpanExporter[F, Chunk](client, uri), config)
     }
 }

--- a/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleter.scala
+++ b/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleter.scala
@@ -17,11 +17,12 @@ object ZipkinHttpSpanCompleter {
     process: TraceProcess,
     host: String = "localhost",
     port: Int = 9411,
-    config: CompleterConfig = CompleterConfig()
+    config: CompleterConfig = CompleterConfig(),
+    protocol: String = "http"
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
       Resource
-        .eval(ZipkinHttpSpanExporter[F, Chunk](client, host, port))
+        .eval(ZipkinHttpSpanExporter[F, Chunk](client, host, port, protocol))
         .flatMap(QueuedSpanCompleter[F](process, _, config))
     }
 

--- a/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporter.scala
+++ b/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporter.scala
@@ -14,11 +14,10 @@ object ZipkinHttpSpanExporter {
   def apply[F[_]: Async, G[_]: Foldable](
     client: Client[F],
     host: String = "localhost",
-    port: Int = 9411
+    port: Int = 9411,
+    protocol: String = "http"
   ): F[SpanExporter[F, G]] =
-    Uri.fromString(s"http://$host:$port/api/v2/spans").liftTo[F].map { uri =>
-      HttpSpanExporter[F, G, String](client, uri, ZipkinSpan.toJsonString[G](_))
-    }
+    Uri.fromString(s"$protocol://$host:$port/api/v2/spans").liftTo[F].map(uri => apply(client, uri))
 
   def apply[F[_]: Async, G[_]: Foldable](client: Client[F], uri: Uri): SpanExporter[F, G] =
     HttpSpanExporter[F, G, String](client, uri, ZipkinSpan.toJsonString[G](_))

--- a/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporter.scala
+++ b/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporter.scala
@@ -2,6 +2,7 @@ package io.janstenpickle.trace4cats.zipkin
 
 import cats.Foldable
 import cats.effect.kernel.Async
+import cats.syntax.either._
 import cats.syntax.functor._
 import io.janstenpickle.trace4cats.`export`.HttpSpanExporter
 import io.janstenpickle.trace4cats.kernel.SpanExporter
@@ -15,7 +16,7 @@ object ZipkinHttpSpanExporter {
     host: String = "localhost",
     port: Int = 9411
   ): F[SpanExporter[F, G]] =
-    Async[F].fromEither(Uri.fromString(s"http://$host:$port/api/v2/spans")).map { uri =>
+    Uri.fromString(s"http://$host:$port/api/v2/spans").liftTo[F].map { uri =>
       HttpSpanExporter[F, G, String](client, uri, ZipkinSpan.toJsonString[G](_))
     }
 

--- a/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporter.scala
+++ b/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporter.scala
@@ -1,32 +1,24 @@
 package io.janstenpickle.trace4cats.zipkin
 
 import cats.Foldable
-import cats.effect.kernel.{Async, Resource}
+import cats.effect.kernel.Async
+import cats.syntax.functor._
 import io.janstenpickle.trace4cats.`export`.HttpSpanExporter
 import io.janstenpickle.trace4cats.kernel.SpanExporter
+import org.http4s.Uri
 import org.http4s.client.Client
-import org.http4s.blaze.client.BlazeClientBuilder
-
-import scala.concurrent.ExecutionContext
 
 object ZipkinHttpSpanExporter {
-
-  def blazeClient[F[_]: Async, G[_]: Foldable](
-    host: String = "localhost",
-    port: Int = 9411,
-    ec: Option[ExecutionContext] = None
-  ): Resource[F, SpanExporter[F, G]] = for {
-    client <- ec.fold(BlazeClientBuilder[F])(BlazeClientBuilder[F].withExecutionContext).resource
-    exporter <- Resource.eval(apply[F, G](client, host, port))
-  } yield exporter
 
   def apply[F[_]: Async, G[_]: Foldable](
     client: Client[F],
     host: String = "localhost",
     port: Int = 9411
   ): F[SpanExporter[F, G]] =
-    HttpSpanExporter[F, G, String](client, s"http://$host:$port/api/v2/spans", ZipkinSpan.toJsonString[G](_))
+    Async[F].fromEither(Uri.fromString(s"http://$host:$port/api/v2/spans")).map { uri =>
+      HttpSpanExporter[F, G, String](client, uri, ZipkinSpan.toJsonString[G](_))
+    }
 
-  def apply[F[_]: Async, G[_]: Foldable](client: Client[F], uri: String): F[SpanExporter[F, G]] =
+  def apply[F[_]: Async, G[_]: Foldable](client: Client[F], uri: Uri): SpanExporter[F, G] =
     HttpSpanExporter[F, G, String](client, uri, ZipkinSpan.toJsonString[G](_))
 }

--- a/modules/zipkin-http-exporter/src/test/resources/logback.xml
+++ b/modules/zipkin-http-exporter/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration name="LogConfig" monitorInterval="5" status="warn">
+    <variable name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>10000</queueSize>
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <root level="${LOG_LEVEL}">
+        <appender-ref ref="ASYNCSTDOUT" />
+    </root>
+</configuration>

--- a/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleterSpec.scala
+++ b/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleterSpec.scala
@@ -5,8 +5,10 @@ import fs2.Chunk
 import io.janstenpickle.trace4cats.`export`.{CompleterConfig, SemanticTags}
 import io.janstenpickle.trace4cats.model.{Batch, CompletedSpan, TraceProcess}
 import io.janstenpickle.trace4cats.test.jaeger.BaseJaegerSpec
+import org.http4s.blaze.client.BlazeClientBuilder
 
 import java.time.Instant
+import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
 class ZipkinHttpSpanCompleterSpec extends BaseJaegerSpec {
@@ -21,10 +23,12 @@ class ZipkinHttpSpanCompleterSpec extends BaseJaegerSpec {
       }
     )
     val batch = Batch(Chunk(updatedSpan.build(process)))
+    val completer = BlazeClientBuilder[IO](global).resource.flatMap { client =>
+      ZipkinHttpSpanCompleter(client, process, "localhost", 9411, CompleterConfig(batchTimeout = 50.millis))
+    }
 
     testCompleter(
-      ZipkinHttpSpanCompleter
-        .blazeClient[IO](process, "localhost", 9411, config = CompleterConfig(batchTimeout = 50.millis)),
+      completer,
       updatedSpan,
       process,
       batchToJaegerResponse(

--- a/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleterSpec.scala
+++ b/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleterSpec.scala
@@ -8,7 +8,6 @@ import io.janstenpickle.trace4cats.test.jaeger.BaseJaegerSpec
 import org.http4s.blaze.client.BlazeClientBuilder
 
 import java.time.Instant
-import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
 class ZipkinHttpSpanCompleterSpec extends BaseJaegerSpec {
@@ -23,7 +22,7 @@ class ZipkinHttpSpanCompleterSpec extends BaseJaegerSpec {
       }
     )
     val batch = Batch(Chunk(updatedSpan.build(process)))
-    val completer = BlazeClientBuilder[IO](global).resource.flatMap { client =>
+    val completer = BlazeClientBuilder[IO].resource.flatMap { client =>
       ZipkinHttpSpanCompleter(client, process, "localhost", 9411, CompleterConfig(batchTimeout = 50.millis))
     }
 

--- a/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporterSpec.scala
+++ b/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporterSpec.scala
@@ -1,12 +1,14 @@
 package io.janstenpickle.trace4cats.zipkin
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import fs2.Chunk
 import io.janstenpickle.trace4cats.`export`.SemanticTags
 import io.janstenpickle.trace4cats.model.{Batch, TraceProcess}
 import io.janstenpickle.trace4cats.test.jaeger.BaseJaegerSpec
+import org.http4s.blaze.client.BlazeClientBuilder
 
 import java.time.Instant
+import scala.concurrent.ExecutionContext.global
 
 class ZipkinHttpSpanExporterSpec extends BaseJaegerSpec {
   it should "Send a batch of spans to Zipkin" in forAll { (batch: Batch[Chunk], process: TraceProcess) =>
@@ -24,9 +26,12 @@ class ZipkinHttpSpanExporterSpec extends BaseJaegerSpec {
           )
         )
       )
+    val exporter = BlazeClientBuilder[IO](global).resource.flatMap { client =>
+      Resource.eval(ZipkinHttpSpanExporter[IO, Chunk](client, "localhost", 9411))
+    }
 
     testExporter(
-      ZipkinHttpSpanExporter.blazeClient[IO, Chunk]("localhost", 9411),
+      exporter,
       updatedBatch,
       batchToJaegerResponse(
         updatedBatch,

--- a/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporterSpec.scala
+++ b/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporterSpec.scala
@@ -8,7 +8,6 @@ import io.janstenpickle.trace4cats.test.jaeger.BaseJaegerSpec
 import org.http4s.blaze.client.BlazeClientBuilder
 
 import java.time.Instant
-import scala.concurrent.ExecutionContext.global
 
 class ZipkinHttpSpanExporterSpec extends BaseJaegerSpec {
   it should "Send a batch of spans to Zipkin" in forAll { (batch: Batch[Chunk], process: TraceProcess) =>
@@ -26,7 +25,7 @@ class ZipkinHttpSpanExporterSpec extends BaseJaegerSpec {
           )
         )
       )
-    val exporter = BlazeClientBuilder[IO](global).resource.flatMap { client =>
+    val exporter = BlazeClientBuilder[IO].resource.flatMap { client =>
       Resource.eval(ZipkinHttpSpanExporter[IO, Chunk](client, "localhost", 9411))
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val scala3 = "3.1.0"
 
     val trace4cats = "0.12.0"
-    val trace4catsExporterHttp = "0.12.0+39-639b2745+20211122-2224"
+    val trace4catsExporterHttp = "0.12.0+41-8ce63144"
     val trace4catsJaegerIntegrationTest = "0.12.0"
 
     val circe = "0.14.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,11 +7,10 @@ object Dependencies {
     val scala3 = "3.1.0"
 
     val trace4cats = "0.12.0"
-    val trace4catsExporterHttp = "0.12.0"
+    val trace4catsExporterHttp = "0.12.0+39-639b2745+20211122-2224"
     val trace4catsJaegerIntegrationTest = "0.12.0"
 
     val circe = "0.14.1"
-    val http4s = "0.23.6"
 
     val kindProjector = "0.13.2"
     val betterMonadicFor = "0.3.1"
@@ -25,7 +24,6 @@ object Dependencies {
     "io.janstenpickle" %% "trace4cats-jaeger-integration-test" % Versions.trace4catsJaegerIntegrationTest
 
   lazy val circeGeneric = "io.circe"        %% "circe-generic"       % Versions.circe
-  lazy val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
 
   lazy val kindProjector = ("org.typelevel" % "kind-projector"     % Versions.kindProjector).cross(CrossVersion.full)
   lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
     val trace4cats = "0.12.0"
     val trace4catsExporterHttp = "0.12.0+41-8ce63144"
-    val trace4catsJaegerIntegrationTest = "0.12.0"
+    val trace4catsJaegerIntegrationTest = "0.12.0+42-5e4d5380"
 
     val circe = "0.14.1"
 
@@ -23,7 +23,7 @@ object Dependencies {
   lazy val trace4catsJaegerIntegrationTest =
     "io.janstenpickle" %% "trace4cats-jaeger-integration-test" % Versions.trace4catsJaegerIntegrationTest
 
-  lazy val circeGeneric = "io.circe"        %% "circe-generic"       % Versions.circe
+  lazy val circeGeneric = "io.circe" %% "circe-generic" % Versions.circe
 
   lazy val kindProjector = ("org.typelevel" % "kind-projector"     % Versions.kindProjector).cross(CrossVersion.full)
   lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor


### PR DESCRIPTION
See https://github.com/trace4cats/trace4cats-exporter-http/pull/45